### PR TITLE
Drop .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,5 +1,0 @@
-[gerrit]
-host=review.opendev.org
-port=29418
-project=nebulous/optimiser-resource-auction-agent.git
-defaultbranch=master


### PR DESCRIPTION
This is obsolete and confusing on GitHub; was used with OpenDev's Gerrit.
